### PR TITLE
Use same follows syntax as flake schema.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ It makes your flake configuration modular and based on the Nix module system. Th
 
 - Flake definition aggregated from all flake-parts modules.
 - Schema as [options](https://github.com/vic/flake-file/blob/main/modules/options.nix).
-- Simplified follows syntax.
 - Supports flake nixConfig.
 - `flake check` ensures files are up to date.
 - App for generator: `nix run .#write-flake`
@@ -156,15 +155,15 @@ Use `nix run .#write-flake` to generate. (Tip: you can install it as a shell hoo
 
 ## Available Options
 
-Options are similar to the flake schema, with a simplified `follows` syntax. See below for details.
+Options are same attributes as flake schema. See below for details.
 
-| Option                             | Description                       |
-| ---------------------------------- | --------------------------------- |
-| `flake-file.description`           | Sets the flake description        |
-| `flake-file.nixConfig`             | Attrset for flake-level nixConfig |
-| `flake-file.inputs.<name>.url`     | URL for a flake input             |
-| `flake-file.inputs.<name>.flake`   | Boolean, is input a flake?        |
-| `flake-file.inputs.<name>.follows` | Map of dependencies to follow     |
+| Option                                          | Description                       |
+| ----------------------------------------------- | --------------------------------- |
+| `flake-file.description`                        | Sets the flake description        |
+| `flake-file.nixConfig`                          | Attrset for flake-level nixConfig |
+| `flake-file.inputs.<name>.url`                  | URL for a flake input             |
+| `flake-file.inputs.<name>.flake`                | Boolean, is input a flake?        |
+| `flake-file.inputs.<name>.inputs.<dep>.follows` | Tree of dependencies to follow    |
 
 Example:
 
@@ -174,29 +173,9 @@ flake-file = {
   nixConfig = {}; # an attrset. currently not typed.
   inputs.<name>.url = "github:foo/bar";
   inputs.<name>.flake = false;
-  # This is the only difference from real flake schema.
-  # maps from `dependency-input` => `flake-input`.
-  inputs.<name>.follows.nixpkgs = "nixpkgs";
+  inputs.<name>.inputs.nixpkgs.follows = "nixpkgs";
 };
 ```
-
-#### About the `follows` Syntax
-
-> **Note:** The `follows` syntax is improved for clarity.
->
-> **Flake schema:**
->
-> ```nix
-> foo.inputs.bar.follows = "baz";
-> ```
->
-> **flake-file syntax:**
->
-> ```nix
-> foo.follows.bar = "baz";
-> ```
->
-> This change makes it easier to reason about and maintain input dependencies.
 
 See also, [options.nix](https://github.com/vic/flake-file/blob/main/modules/options.nix).
 
@@ -265,12 +244,6 @@ This section outlines recommended steps for adopting `flake-file` in your own re
        inputs = {
          flake-file.url = "github:vic/flake-file";
          # ... all your other flake inputs here.
-         #
-         # Update your dependencies follows from:
-         #   foo.inputs.bar.follows = "baz";
-         # into:
-         #   foo.follows.bar = "baz";
-         #
        };
        nixConfig = { }; # if you had any.
        description = "Your flake description";

--- a/modules/allfollow.nix
+++ b/modules/allfollow.nix
@@ -10,8 +10,11 @@ let
     );
 
   new-input = url: follows: {
-    inherit url follows;
+    inherit url;
     flake = true;
+    inputs = lib.mapAttrs (_: follows: {
+      inherit follows;
+    }) follows;
   };
 
   add-allfollow-input = merge-missing {

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -1,43 +1,105 @@
 { lib, ... }:
-{
-  options.flake-file = lib.mkOption {
+let
+  outputs-option = lib.mkOption {
+    description = ''
+      Nix code for outputs function.
+
+      We recommend this function code to be short, used only to import a file.
+    '';
+    type = lib.types.str;
+    default = ''
+      inputs: import ./outputs.nix inputs
+    '';
+    example = lib.literalExample ''
+      inputs: inputs.flake-parts.lib.mkFlake { inherit inputs; } ./module
+    '';
+  };
+
+  inputs-follow-option = lib.mkOption {
+    description = "input dependencies";
+    default = { };
+    type = lib.types.lazyAttrsOf (
+      lib.types.submodule {
+        options = {
+          follows = lib.mkOption {
+            description = "flake input path to follow";
+            default = "";
+            type = lib.types.string;
+          };
+          inputs = inputs-follow-option;
+        };
+      }
+    );
+  };
+
+  inputs-option = lib.mkOption {
+    default = { };
+    description = "Flake inputs";
+    apply =
+      inputs:
+      if inputs ? allfollow then (import ./allfollow.nix lib).add-allfollow-input inputs else inputs;
+    type = lib.types.lazyAttrsOf (
+      lib.types.submodule {
+        options = {
+          url = lib.mkOption {
+            description = "source url";
+            type = lib.types.str;
+          };
+          flake = lib.mkOption {
+            description = "is it a flake?";
+            type = lib.types.bool;
+            default = true;
+          };
+          inputs = inputs-follow-option;
+        };
+      }
+    );
+
+  };
+
+  do-not-edit-option = lib.mkOption {
+    default = ''
+      # DO-NOT-EDIT. This file was auto-generated using github:vic/flake-file.
+      # Use `nix run .#write-flake` to regenerate it.
+    '';
+    description = "header comment";
+    type = lib.types.str;
+    apply =
+      value:
+      lib.pipe value [
+        (s: if lib.hasPrefix "#" s then s else "# " + s)
+        (s: if lib.hasSuffix "\n" s then s else s + "\n")
+      ];
+    example = lib.literalExample ''
+      "DO-NOT-EDIT"
+    '';
+
+  };
+
+  formatter-option = lib.mkOption {
+    description = ''
+      Formatter for flake.nix file.
+
+      It is a function fron pkgs to a shell command (string).
+
+      The command takes flake.nix as first argument.
+    '';
+    type = lib.types.functionTo lib.types.str;
+    default = pkgs: pkgs.lib.getExe pkgs.nixfmt-rfc-style;
+    example = lib.literalExample ''
+      pkgs: pkgs.lib.getExe pkgs.nixfmt-rfc-style
+    '';
+  };
+
+  flake-file-option = lib.mkOption {
     description = "A nix flake.";
     default = { };
     type = lib.types.submodule (
       { ... }:
       {
         options = {
-          do-not-edit = lib.mkOption {
-            default = ''
-              # DO-NOT-EDIT. This file was auto-generated using github:vic/flake-file.
-              # Use `nix run .#write-flake` to regenerate it.
-            '';
-            description = "header comment";
-            type = lib.types.str;
-            apply =
-              value:
-              lib.pipe value [
-                (s: if lib.hasPrefix "#" s then s else "# " + s)
-                (s: if lib.hasSuffix "\n" s then s else s + "\n")
-              ];
-            example = lib.literalExample ''
-              "DO-NOT-EDIT"
-            '';
-          };
-          formatter = lib.mkOption {
-            description = ''
-              Formatter for flake.nix file.
-
-              It is a function fron pkgs to a shell command (string).
-
-              The command takes flake.nix as first argument.
-            '';
-            type = lib.types.functionTo lib.types.str;
-            default = pkgs: pkgs.lib.getExe pkgs.nixfmt-rfc-style;
-            example = lib.literalExample ''
-              pkgs: pkgs.lib.getExe pkgs.nixfmt-rfc-style
-            '';
-          };
+          do-not-edit = do-not-edit-option;
+          formatter = formatter-option;
           description = lib.mkOption {
             default = "";
             description = "Flake description";
@@ -48,52 +110,15 @@
             description = "nix config";
             type = lib.types.attrs;
           };
-          outputs = lib.mkOption {
-            description = ''
-              Nix code for outputs function.
-
-              We recommend this function code to be short, used only to import a file.
-            '';
-            type = lib.types.str;
-            default = ''
-              inputs: import ./outputs.nix inputs
-            '';
-            example = lib.literalExample ''
-              inputs: inputs.flake-parts.lib.mkFlake { inherit inputs; } ./module
-            '';
-          };
-          inputs = lib.mkOption {
-            default = { };
-            description = "Flake inputs";
-            apply =
-              inputs:
-              if inputs ? allfollow then (import ./allfollow.nix lib).add-allfollow-input inputs else inputs;
-            type = lib.types.lazyAttrsOf (
-              lib.types.submodule (
-                { ... }:
-                {
-                  options = {
-                    url = lib.mkOption {
-                      description = "source url";
-                      type = lib.types.str;
-                    };
-                    flake = lib.mkOption {
-                      description = "is it a flake?";
-                      type = lib.types.bool;
-                      default = true;
-                    };
-                    follows = lib.mkOption {
-                      description = "input dependencies follows";
-                      default = { };
-                      type = lib.types.lazyAttrsOf lib.types.str; # TODO: type.oneOf flake.input.names
-                    };
-                  };
-                }
-              )
-            );
-          };
+          outputs = outputs-option;
+          inputs = inputs-option;
         };
       }
     );
+
   };
+
+in
+{
+  options.flake-file = flake-file-option;
 }

--- a/modules/write-flake.nix
+++ b/modules/write-flake.nix
@@ -64,20 +64,25 @@
             else
               "";
 
+          inputsFollow = lib.mapAttrs (
+            _: input:
+            { }
+            // (if !input ? follows || input.follows == { } then { } else { inherit (input) follows; })
+            // (if !input ? inputs || input.inputs == { } then { } else { inputs = inputsFollow input.inputs; })
+          );
+
           inputsExpr = lib.mapAttrs (
             _name: input:
             {
               inherit (input) url;
             }
-            // (if input.flake then { } else { flake = false; })
+            // (if !input ? flake || input.flake then { } else { flake = false; })
             // (
-              if input.follows == { } then
+              if !input ? inputs || input.inputs == { } then
                 { }
               else
                 {
-                  inputs = lib.mapAttrs (_: follows: {
-                    inherit follows;
-                  }) input.follows;
+                  inputs = inputsFollow input.inputs;
                 }
             )
           ) flake-file.inputs;


### PR DESCRIPTION
This allows copy and paste of original flake inputs when migrating.

Fixes #4 