### PR TITLE
re-enable allfollow.

### DIFF
--- a/.github/workflows/flake-check.yaml
+++ b/.github/workflows/flake-check.yaml
@@ -4,7 +4,33 @@ on:
     branches: ["main"]
   pull_request:
 jobs:
-  flake-check:
+  find-flakes:
+    name: Find Flakes
+    runs-on: ubuntu-latest
+    outputs:
+      flakes: ${{ steps.flakes.outputs.flakes }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: flakes
+        run: |
+          flakes=$(find . -mindepth 2 -name flake.nix -print0 | xargs -0 dirname | jq -R . | jq -sc .)
+          echo "$flakes"
+          echo "flakes=$flakes" >> $GITHUB_OUTPUT
+  flake:
+    name: Check flake ${{matrix.flake}}
+    needs: [find-flakes]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        flake: ${{ fromJSON(needs.find-flakes.outputs.flakes) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: wimpysworld/nothing-but-nix@main
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - run: nix flake check ${{matrix.flake}} -L --override-input flake-file $PWD
+  nix-fmt:
+    name: Nix Format
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -12,6 +38,3 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - run: nix run -L --override-input flake-file $PWD ./dev#fmt -- --ci
-      - run: nix run -L --override-input flake-file $PWD ./dev#regen -- -L
-      - name: check no files were modified
-        run: test "0" -eq "$(git diff --shortstat | wc -l)" || (git diff ; exit 1)

--- a/dev/flake.lock
+++ b/dev/flake.lock
@@ -2,9 +2,15 @@
   "nodes": {
     "allfollow": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay",
-        "systems": "systems"
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": [
+          "rust-overlay"
+        ],
+        "systems": [
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1751969493,
@@ -22,7 +28,9 @@
     },
     "devshell": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1741473158,
@@ -40,11 +48,11 @@
     },
     "flake-file": {
       "locked": {
-        "lastModified": 1752574566,
-        "narHash": "sha256-Z/EHdXl1Kej6V8ZMlnh+k48zyJDfMzcjPgLozBsJNV8=",
+        "lastModified": 1752599315,
+        "narHash": "sha256-9xDnXXfSfMocJk6gVe/6KO/dZ0GUWe5EmlxGvXt4n3o=",
         "owner": "vic",
         "repo": "flake-file",
-        "rev": "4c83bd7604a39640274c8b7e3a85b11742d7aec6",
+        "rev": "d5b2e47469a13e5f117ad4c4566580cd07cdaa15",
         "type": "github"
       },
       "original": {
@@ -55,7 +63,9 @@
     },
     "flake-parts": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
+        "nixpkgs-lib": [
+          "nixpkgs-lib"
+        ]
       },
       "locked": {
         "lastModified": 1751413152,
@@ -86,76 +96,13 @@
         "type": "github"
       }
     },
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1751498133,
-        "narHash": "sha256-QWJ+NQbMU+NcU2xiyo7SNox1fAuwksGlQhpzBl76g1I=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d55716bb59b91ae9d1ced4b1ccdea7a442ecbfdb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1751159883,
-        "narHash": "sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "14a40a1d7fb9afa4739275ac642ed7301a9ba1ab",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1722073938,
-        "narHash": "sha256-OpX0StkL8vpXyWOGUD6G+MA26wAXK6SpT94kLJXo6B4=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e36e9f57337d0ff0cf77aceb58af4c805472bfae",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1752446735,
-        "narHash": "sha256-Nz2vtUEaRB/UjvPfuhHpez060P/4mvGpXW4JCDIboA4=",
+        "lastModified": 1752596105,
+        "narHash": "sha256-lFNVsu/mHLq3q11MuGkMhUUoSXEdQjCHvpReaGP1S2k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a421ac6595024edcfbb1ef950a3712b89161c359",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1747958103,
-        "narHash": "sha256-qmmFCrfBwSHoWw7cVK4Aj+fns+c54EBP8cGqp/yK410=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "fe51d34885f7b5e3e7b59572796e1bcb427eccb1",
+        "rev": "dab3a6e781554f965bde3def0aa2fda4eb8f1708",
         "type": "github"
       },
       "original": {
@@ -173,30 +120,12 @@
         "flake-parts": "flake-parts",
         "import-tree": "import-tree",
         "nixpkgs": "nixpkgs_3",
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ],
         "rust-overlay": "rust-overlay_2",
         "systems": "systems_2",
         "treefmt-nix": "treefmt-nix"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "allfollow",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1751596734,
-        "narHash": "sha256-1tQOwmn3jEUQjH0WDJyklC+hR7Bj+iqx6ChtRX2QiPA=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "e28ba067a9368286a8bc88b68dc2ca92181a09f0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
       }
     },
     "rust-overlay_2": {
@@ -206,32 +135,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1752547600,
-        "narHash": "sha256-0vUE42ji4mcCvQO8CI0Oy8LmC6u2G4qpYldZbZ26MLc=",
+        "lastModified": 1752633862,
+        "narHash": "sha256-Bj7ozT1+5P7NmvDcuAXJvj56txcXuAhk3Vd9FdWFQzk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9127ca1f5a785b23a2fc1c74551a27d3e8b9a28b",
+        "rev": "8668ca94858206ac3db0860a9dec471de0d995f8",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     },
@@ -252,7 +165,9 @@
     },
     "treefmt-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1752055615,

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -23,6 +23,9 @@
     nixpkgs = {
       url = "github:nixos/nixpkgs/nixpkgs-unstable";
     };
+    nixpkgs-lib = {
+      follows = "nixpkgs";
+    };
     rust-overlay = {
       inputs = {
         nixpkgs = {

--- a/dev/modules/devshell.nix
+++ b/dev/modules/devshell.nix
@@ -7,7 +7,7 @@
   ];
 
   perSystem =
-    { self', ... }:
+    { pkgs, self', ... }:
     {
       devshells.default.commands = [
         {
@@ -15,9 +15,21 @@
           package = self'.packages.regen;
         }
         {
+          help = "run a command on each sub flake";
+          package = self'.packages.each;
+        }
+        {
           name = "fmt";
           help = "format all files in repo";
           command = "nix run ./dev#fmt --override-input flake-file .";
+        }
+        {
+          name = "update";
+          help = "update all flakes and prune locks";
+          command = ''
+            ${pkgs.lib.getExe self'.packages.each} nix flake update
+            ${pkgs.lib.getExe self'.packages.each} nix run --inputs-from . allfollow -- prune --in-place --pretty
+          '';
         }
         {
           name = "check";

--- a/dev/modules/regen.nix
+++ b/dev/modules/regen.nix
@@ -44,5 +44,12 @@
           ${each} ${puke} --override-input flake-file "$PWD"
         '';
       };
+
+      packages.check = pkgs.writeShellApplication {
+        name = "check";
+        text = ''
+          ${each} nix flake check -L --override-input flake-file "$PWD"
+        '';
+      };
     };
 }

--- a/modules/allfollow.nix
+++ b/modules/allfollow.nix
@@ -37,21 +37,18 @@ let
         name = "allfollow-run";
         runtimeInputs = [
           pkgs.nix
-          pkgs.difftastic
-          pkgs.jq
+          pkgs.delta
           inputs'.allfollow.packages.default
         ];
         text = ''
-          if [ "apply" == "''${1:-}" ]; then
+          set -e
+          if [ "apply" == "$1" ]; then
             nix flake lock
-            allfollow prune --pretty "''${2}" -o - | jq -S . > flake.lock.pruned
-            mv flake.lock.pruned "''${2}"
+            allfollow prune --pretty flake.lock --in-place
           fi
-          if [ "check" == "''${1:-}" ]; then
-            allfollow prune "''${2}" --pretty -o pruned.lock
-            allfollow count --json --pretty -o - pruned.lock | jq -S . > pruned.json
-            allfollow count --json --pretty -o - "''${2}" | jq -S . > current.json
-            difft --exit-code --display inline pruned.json current.json
+          if [ "check" == "$1" ]; then
+            allfollow prune --pretty "$2" -o pruned.lock
+            delta --paging never pruned.lock "$2"
           fi
         '';
       }

--- a/modules/dendritic/nixpkgs.nix
+++ b/modules/dendritic/nixpkgs.nix
@@ -3,6 +3,7 @@
 
   flake-file.inputs = {
     nixpkgs.url = lib.mkDefault "github:nixos/nixpkgs/nixpkgs-unstable";
+    nixpkgs-lib.follows = "nixpkgs";
   };
 
 }

--- a/modules/write-flake.nix
+++ b/modules/write-flake.nix
@@ -121,7 +121,7 @@
         text = ''
           set -e
           cp ${formatted} flake.nix
-          # ${lib.getExe allfollow-run} apply
+          ${lib.getExe allfollow-run} apply
         '';
       };
 
@@ -132,8 +132,8 @@
           }
           ''
             set -e
-            delta --paging never --side-by-side ${formatted} ${inputs.self}/flake.nix
-            # ${lib.getExe allfollow-run} check ${inputs.self}/flake.lock
+            delta --paging never ${formatted} ${inputs.self}/flake.nix
+            ${lib.getExe allfollow-run} check ${inputs.self}/flake.lock
             touch $out
           '';
     in

--- a/templates/default/flake.lock
+++ b/templates/default/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-file": {
       "locked": {
-        "lastModified": 1752574566,
-        "narHash": "sha256-Z/EHdXl1Kej6V8ZMlnh+k48zyJDfMzcjPgLozBsJNV8=",
+        "lastModified": 1752599315,
+        "narHash": "sha256-9xDnXXfSfMocJk6gVe/6KO/dZ0GUWe5EmlxGvXt4n3o=",
         "owner": "vic",
         "repo": "flake-file",
-        "rev": "4c83bd7604a39640274c8b7e3a85b11742d7aec6",
+        "rev": "d5b2e47469a13e5f117ad4c4566580cd07cdaa15",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1752446735,
-        "narHash": "sha256-Nz2vtUEaRB/UjvPfuhHpez060P/4mvGpXW4JCDIboA4=",
+        "lastModified": 1752596105,
+        "narHash": "sha256-lFNVsu/mHLq3q11MuGkMhUUoSXEdQjCHvpReaGP1S2k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a421ac6595024edcfbb1ef950a3712b89161c359",
+        "rev": "dab3a6e781554f965bde3def0aa2fda4eb8f1708",
         "type": "github"
       },
       "original": {

--- a/templates/dendritic/flake.lock
+++ b/templates/dendritic/flake.lock
@@ -2,9 +2,15 @@
   "nodes": {
     "allfollow": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay",
-        "systems": "systems"
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": [
+          "rust-overlay"
+        ],
+        "systems": [
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1751969493,
@@ -22,7 +28,9 @@
     },
     "devshell": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1741473158,
@@ -40,11 +48,11 @@
     },
     "flake-file": {
       "locked": {
-        "lastModified": 1752574566,
-        "narHash": "sha256-Z/EHdXl1Kej6V8ZMlnh+k48zyJDfMzcjPgLozBsJNV8=",
+        "lastModified": 1752599315,
+        "narHash": "sha256-9xDnXXfSfMocJk6gVe/6KO/dZ0GUWe5EmlxGvXt4n3o=",
         "owner": "vic",
         "repo": "flake-file",
-        "rev": "4c83bd7604a39640274c8b7e3a85b11742d7aec6",
+        "rev": "d5b2e47469a13e5f117ad4c4566580cd07cdaa15",
         "type": "github"
       },
       "original": {
@@ -55,7 +63,9 @@
     },
     "flake-parts": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
+        "nixpkgs-lib": [
+          "nixpkgs-lib"
+        ]
       },
       "locked": {
         "lastModified": 1751413152,
@@ -86,76 +96,13 @@
         "type": "github"
       }
     },
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1751498133,
-        "narHash": "sha256-QWJ+NQbMU+NcU2xiyo7SNox1fAuwksGlQhpzBl76g1I=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d55716bb59b91ae9d1ced4b1ccdea7a442ecbfdb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1751159883,
-        "narHash": "sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "14a40a1d7fb9afa4739275ac642ed7301a9ba1ab",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1722073938,
-        "narHash": "sha256-OpX0StkL8vpXyWOGUD6G+MA26wAXK6SpT94kLJXo6B4=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e36e9f57337d0ff0cf77aceb58af4c805472bfae",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1752446735,
-        "narHash": "sha256-Nz2vtUEaRB/UjvPfuhHpez060P/4mvGpXW4JCDIboA4=",
+        "lastModified": 1752596105,
+        "narHash": "sha256-lFNVsu/mHLq3q11MuGkMhUUoSXEdQjCHvpReaGP1S2k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a421ac6595024edcfbb1ef950a3712b89161c359",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1747958103,
-        "narHash": "sha256-qmmFCrfBwSHoWw7cVK4Aj+fns+c54EBP8cGqp/yK410=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "fe51d34885f7b5e3e7b59572796e1bcb427eccb1",
+        "rev": "dab3a6e781554f965bde3def0aa2fda4eb8f1708",
         "type": "github"
       },
       "original": {
@@ -173,30 +120,12 @@
         "flake-parts": "flake-parts",
         "import-tree": "import-tree",
         "nixpkgs": "nixpkgs_3",
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ],
         "rust-overlay": "rust-overlay_2",
         "systems": "systems_2",
         "treefmt-nix": "treefmt-nix"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "allfollow",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1751596734,
-        "narHash": "sha256-1tQOwmn3jEUQjH0WDJyklC+hR7Bj+iqx6ChtRX2QiPA=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "e28ba067a9368286a8bc88b68dc2ca92181a09f0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
       }
     },
     "rust-overlay_2": {
@@ -206,32 +135,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1752547600,
-        "narHash": "sha256-0vUE42ji4mcCvQO8CI0Oy8LmC6u2G4qpYldZbZ26MLc=",
+        "lastModified": 1752633862,
+        "narHash": "sha256-Bj7ozT1+5P7NmvDcuAXJvj56txcXuAhk3Vd9FdWFQzk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9127ca1f5a785b23a2fc1c74551a27d3e8b9a28b",
+        "rev": "8668ca94858206ac3db0860a9dec471de0d995f8",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     },
@@ -252,7 +165,9 @@
     },
     "treefmt-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1752055615,

--- a/templates/dendritic/flake.nix
+++ b/templates/dendritic/flake.nix
@@ -23,6 +23,9 @@
     nixpkgs = {
       url = "github:nixos/nixpkgs/nixpkgs-unstable";
     };
+    nixpkgs-lib = {
+      follows = "nixpkgs";
+    };
     rust-overlay = {
       inputs = {
         nixpkgs = {


### PR DESCRIPTION
Now that allfollow is [deterministic](https://github.com/spikespaz/allfollow/issues/1) we no longer have to use jq to sort its output.

We now use `delta` instead of `difftasitc` to fail if flake.lock was not already pruned.

I'm not sure now that we need an `allfollow check` command, since it is better for users to see a nice diff as error message.

Related:
https://github.com/spikespaz/allfollow/pull/7