### PR TITLE
fix: remove allfollow input from dendritic/basic.nix

### DIFF
--- a/modules/dendritic/basic.nix
+++ b/modules/dendritic/basic.nix
@@ -7,6 +7,5 @@
 
   flake-file.inputs = {
     flake-file.url = lib.mkDefault "github:vic/flake-file";
-    allfollow.url = lib.mkDefault "github:spikespaz/allfollow";
   };
 }


### PR DESCRIPTION
It is now included by our new flakeModules.allfollow