### PR TITLE
fix: Inherited allfollow in flakeModules

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -22,7 +22,7 @@ let
 in
 {
   flakeModules = {
-    inherit default dendritic;
+    inherit default allfollow dendritic;
   };
   templates.default = {
     description = "default template";


### PR DESCRIPTION
Due to not being inherited flakeModules the allfollow module could not be imported on the user-end. It is inherited now.

This closes #17.