### PR TITLE
refactor: reorganize modules and update prune-lock API

### DIFF
--- a/modules/allfollow.nix
+++ b/modules/allfollow.nix
@@ -1,7 +1,0 @@
-{ lib, inputs, ... }:
-{
-  flake-file.inputs.allfollow.url = "github:spikespaz/allfollow";
-  flake-file.prune-lock.enable = lib.mkDefault true;
-  flake-file.prune-lock.command =
-    pkgs: "${pkgs.lib.getExe inputs.allfollow.packages.${pkgs.system}.default} prune --pretty -o -";
-}

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -8,7 +8,7 @@ let
 
   allfollow = {
     imports = [
-      ./allfollow.nix
+      ./prune-lock/allfollow.nix
     ];
   };
 
@@ -16,13 +16,17 @@ let
     imports = [
       default
       allfollow
-      ./dendritic.nix
+      ./dendritic
     ];
   };
 in
 {
   flakeModules = {
-    inherit default allfollow dendritic;
+    inherit
+      default
+      allfollow
+      dendritic
+      ;
   };
   templates.default = {
     description = "default template";

--- a/modules/dendritic.nix
+++ b/modules/dendritic.nix
@@ -1,9 +1,0 @@
-{
-  imports = [
-    ./dendritic/dendritic.nix
-    ./dendritic/basic.nix
-    ./dendritic/formatter.nix
-    ./dendritic/nixpkgs.nix
-    ./dendritic/systems.nix
-  ];
-}

--- a/modules/dendritic/default.nix
+++ b/modules/dendritic/default.nix
@@ -1,0 +1,9 @@
+{
+  imports = [
+    ./dendritic.nix
+    ./basic.nix
+    ./formatter.nix
+    ./nixpkgs.nix
+    ./systems.nix
+  ];
+}

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -20,21 +20,18 @@ let
     type = lib.types.submodule {
       options = {
         enable = lib.mkEnableOption "Should we automatically prune flake.lock";
-        command = lib.mkOption {
+        program = lib.mkOption {
           description = ''
-            Function from pkgs to a command (string) used to prune flake.lock.
+            Function from pkgs to an exe derivation used to prune flake.lock.
 
-            The command takes the flake.lock location as only argument
-            and is expected to produce a pruned version into stdout.
+            The program takes the flake.lock location as first postional argument
+            and is expected to produce a pruned version into the second argument.
 
             The output is expected to be deterministic.
           '';
-          # TODO: https://github.com/NixOS/nixpkgs/pull/422286
-          example = lib.literalExample ''
-            pkgs: "''${pkgs.lib.getExe pkgs.allfollow} prune -o - --pretty"
-          '';
-          type = lib.types.functionTo lib.types.str;
-          default = _: "cat";
+          example = lib.literalExample (builtins.readFile ./prune-lock/_nothing.nix);
+          type = lib.types.functionTo lib.types.unspecified;
+          default = import ./prune-lock/_nothing.nix;
         };
       };
     };

--- a/modules/prune-lock/_nothing.nix
+++ b/modules/prune-lock/_nothing.nix
@@ -1,0 +1,8 @@
+# Example pruning app that does nothing.
+pkgs:
+pkgs.writeShellApplication {
+  name = "cp";
+  text = ''
+    cp "$1" "$2"
+  '';
+}

--- a/modules/prune-lock/allfollow.nix
+++ b/modules/prune-lock/allfollow.nix
@@ -1,0 +1,14 @@
+{ lib, inputs, ... }:
+{
+  flake-file.inputs.allfollow.url = lib.mkDefault "github:spikespaz/allfollow";
+  flake-file.prune-lock.enable = lib.mkDefault (inputs ? allfollow);
+  flake-file.prune-lock.program =
+    pkgs:
+    pkgs.writeShellApplication {
+      name = "allfollow";
+      runtimeInputs = [ inputs.allfollow.packages.${pkgs.system}.default ];
+      text = ''
+        allfollow prune --pretty "$1" -o "$2"
+      '';
+    };
+}


### PR DESCRIPTION
- Move allfollow.nix to modules/prune-lock/ directory
- Convert dendritic.nix to dendritic/ directory with default.nix
- Update prune-lock API from command string to program derivation
- Add _nothing.nix as example pruning app that does nothing
- Update allfollow.nix to use writeShellApplication pattern
- Rename check-flake to check-flake-file for clarity
- Add standalone prune-lock package

BREAKING CHANGE: prune-lock.command option replaced with prune-lock.program

In preparation for #19 