### PR TITLE
refactor: extract option definitions into separate files

### DIFF
--- a/modules/_options/do-not-edit.nix
+++ b/modules/_options/do-not-edit.nix
@@ -1,0 +1,18 @@
+{ lib, ... }:
+lib.mkOption {
+  default = ''
+    # DO-NOT-EDIT. This file was auto-generated using github:vic/flake-file.
+    # Use `nix run .#write-flake` to regenerate it.
+  '';
+  description = "header comment";
+  type = lib.types.str;
+  apply =
+    value:
+    lib.pipe value [
+      (s: if lib.hasPrefix "#" s then s else "# " + s)
+      (s: if lib.hasSuffix "\n" s then s else s + "\n")
+    ];
+  example = lib.literalExample ''
+    "DO-NOT-EDIT"
+  '';
+}

--- a/modules/_options/formatter.nix
+++ b/modules/_options/formatter.nix
@@ -1,0 +1,15 @@
+{ lib, ... }:
+lib.mkOption {
+  description = ''
+    Formatter for flake.nix file.
+
+    It is a function from pkgs to a shell command (string).
+
+    The command takes flake.nix as first argument.
+  '';
+  type = lib.types.functionTo lib.types.str;
+  default = pkgs: pkgs.lib.getExe pkgs.nixfmt-rfc-style;
+  example = lib.literalExample ''
+    pkgs: pkgs.lib.getExe pkgs.nixfmt-rfc-style
+  '';
+}

--- a/modules/_options/inputs.nix
+++ b/modules/_options/inputs.nix
@@ -1,0 +1,47 @@
+{ lib, ... }:
+let
+  follows-option = lib.mkOption {
+    description = "flake input path to follow";
+    default = "";
+    type = lib.types.str;
+  };
+
+  inputs-follow-option = lib.mkOption {
+    description = "input dependencies";
+    default = { };
+    type = lib.types.lazyAttrsOf (
+      lib.types.submodule {
+        options = {
+          follows = follows-option;
+          inputs = inputs-follow-option;
+        };
+      }
+    );
+  };
+
+  inputs-option = lib.mkOption {
+    default = { };
+    description = "Flake inputs";
+    type = lib.types.lazyAttrsOf (
+      lib.types.submodule {
+        options = {
+          url = lib.mkOption {
+            description = "source url";
+            default = "";
+            type = lib.types.str;
+          };
+          flake = lib.mkOption {
+            description = "is it a flake?";
+            type = lib.types.bool;
+            default = true;
+          };
+          follows = follows-option;
+          inputs = inputs-follow-option;
+        };
+      }
+    );
+
+  };
+
+in
+inputs-option

--- a/modules/_options/outputs.nix
+++ b/modules/_options/outputs.nix
@@ -1,0 +1,15 @@
+{ lib, ... }:
+lib.mkOption {
+  description = ''
+    Nix code for outputs function.
+
+    We recommend this function code to be short, used only to import a file.
+  '';
+  type = lib.types.str;
+  default = ''
+    inputs: import ./outputs.nix inputs
+  '';
+  example = lib.literalExample ''
+    inputs: inputs.flake-parts.lib.mkFlake { inherit inputs; } ./modules
+  '';
+}

--- a/modules/_options/prune-lock.nix
+++ b/modules/_options/prune-lock.nix
@@ -1,0 +1,22 @@
+{ lib, ... }:
+lib.mkOption {
+  default = { };
+  type = lib.types.submodule {
+    options = {
+      enable = lib.mkEnableOption "Should we automatically prune flake.lock";
+      program = lib.mkOption {
+        description = ''
+          Function from pkgs to an exe derivation used to prune flake.lock.
+
+          The program takes the flake.lock location as first positional argument
+          and is expected to produce a pruned version into the second argument.
+
+          The output is expected to be deterministic.
+        '';
+        example = lib.literalExample (builtins.readFile ./../prune-lock/_nothing.nix);
+        type = lib.types.functionTo lib.types.unspecified;
+        default = import ./../prune-lock/_nothing.nix;
+      };
+    };
+  };
+}

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -1,146 +1,39 @@
 { lib, ... }:
 let
-  outputs-option = lib.mkOption {
-    description = ''
-      Nix code for outputs function.
-
-      We recommend this function code to be short, used only to import a file.
-    '';
-    type = lib.types.str;
-    default = ''
-      inputs: import ./outputs.nix inputs
-    '';
-    example = lib.literalExample ''
-      inputs: inputs.flake-parts.lib.mkFlake { inherit inputs; } ./modules
-    '';
-  };
-
-  prune-lock-option = lib.mkOption {
+  flake-file-option = lib.mkOption {
+    description = "A nix flake.";
     default = { };
     type = lib.types.submodule {
-      options = {
-        enable = lib.mkEnableOption "Should we automatically prune flake.lock";
-        program = lib.mkOption {
-          description = ''
-            Function from pkgs to an exe derivation used to prune flake.lock.
-
-            The program takes the flake.lock location as first postional argument
-            and is expected to produce a pruned version into the second argument.
-
-            The output is expected to be deterministic.
-          '';
-          example = lib.literalExample (builtins.readFile ./prune-lock/_nothing.nix);
-          type = lib.types.functionTo lib.types.unspecified;
-          default = import ./prune-lock/_nothing.nix;
+      options = flake-options // {
+        description = lib.mkOption {
+          default = "";
+          description = "Flake description";
+          type = lib.types.str;
+        };
+        nixConfig = lib.mkOption {
+          default = { };
+          description = "nix config";
+          type = lib.types.attrs;
         };
       };
     };
   };
 
-  follows-option = lib.mkOption {
-    description = "flake input path to follow";
-    default = "";
-    type = lib.types.str;
-  };
-
-  inputs-follow-option = lib.mkOption {
-    description = "input dependencies";
-    default = { };
-    type = lib.types.lazyAttrsOf (
-      lib.types.submodule {
-        options = {
-          follows = follows-option;
-          inputs = inputs-follow-option;
-        };
-      }
-    );
-  };
-
-  inputs-option = lib.mkOption {
-    default = { };
-    description = "Flake inputs";
-    type = lib.types.lazyAttrsOf (
-      lib.types.submodule {
-        options = {
-          url = lib.mkOption {
-            description = "source url";
-            default = "";
-            type = lib.types.str;
-          };
-          flake = lib.mkOption {
-            description = "is it a flake?";
-            type = lib.types.bool;
-            default = true;
-          };
-          follows = follows-option;
-          inputs = inputs-follow-option;
-        };
-      }
-    );
-
-  };
-
-  do-not-edit-option = lib.mkOption {
-    default = ''
-      # DO-NOT-EDIT. This file was auto-generated using github:vic/flake-file.
-      # Use `nix run .#write-flake` to regenerate it.
-    '';
-    description = "header comment";
-    type = lib.types.str;
-    apply =
-      value:
-      lib.pipe value [
-        (s: if lib.hasPrefix "#" s then s else "# " + s)
-        (s: if lib.hasSuffix "\n" s then s else s + "\n")
+  flake-options =
+    lib.pipe
+      [
+        "inputs"
+        "outputs"
+        "do-not-edit"
+        "formatter"
+        "prune-lock"
+      ]
+      [
+        (map (n: {
+          ${n} = import ./_options/${n}.nix { inherit lib; };
+        }))
+        lib.mergeAttrsList
       ];
-    example = lib.literalExample ''
-      "DO-NOT-EDIT"
-    '';
-
-  };
-
-  formatter-option = lib.mkOption {
-    description = ''
-      Formatter for flake.nix file.
-
-      It is a function fron pkgs to a shell command (string).
-
-      The command takes flake.nix as first argument.
-    '';
-    type = lib.types.functionTo lib.types.str;
-    default = pkgs: pkgs.lib.getExe pkgs.nixfmt-rfc-style;
-    example = lib.literalExample ''
-      pkgs: pkgs.lib.getExe pkgs.nixfmt-rfc-style
-    '';
-  };
-
-  flake-file-option = lib.mkOption {
-    description = "A nix flake.";
-    default = { };
-    type = lib.types.submodule (
-      { ... }:
-      {
-        options = {
-          do-not-edit = do-not-edit-option;
-          prune-lock = prune-lock-option;
-          formatter = formatter-option;
-          description = lib.mkOption {
-            default = "";
-            description = "Flake description";
-            type = lib.types.str;
-          };
-          nixConfig = lib.mkOption {
-            default = { };
-            description = "nix config";
-            type = lib.types.attrs;
-          };
-          outputs = outputs-option;
-          inputs = inputs-option;
-        };
-      }
-    );
-
-  };
 
 in
 {


### PR DESCRIPTION
- Create modules/_options/ directory with individual option files
- Split large options.nix into modular components:
  - do-not-edit.nix: header comment option
  - formatter.nix: flake formatter configuration
  - inputs.nix: flake inputs with follows support
  - outputs.nix: outputs function configuration
  - prune-lock.nix: lock pruning options
- Simplify main options.nix using dynamic imports
- Improve code organization and maintainability