### PR TITLE
Add nix-auto-follow as an allfollow alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ The following is a complete example from our [`templates/dendritic`](https://git
 
 - Enables [automatic flake.lock flattening](#automatic-flakelock-flattening) using [spikespaz/allfollow](https://github.com/spikespaz/allfollow)
 
+#### [`flakeModules.nix-auto-follow`](https://github.com/vic/flake-file/tree/main/modules/prune-lock/nix-auto-follow.nix)
+
+- Enables [automatic flake.lock flattening](#automatic-flakelock-flattening) using [fzakaria/nix-auto-follow](https://github.com/fzakaria/nix-auto-follow)
+
 #### [`flakeModules.dendritic`](https://github.com/vic/flake-file/tree/main/modules/dendritic/default.nix)
 
 - Includes flakeModules.default.
@@ -270,12 +274,19 @@ You can use the `prune-lock` [options](https://github.com/vic/flake-file/blob/ma
 to specify a command that `flake-file` will use whenever your flake.nix file is generated
 to flatten your flake.lock dependency tree.
 
-We also provide a [`flakeModules.allfollow`](https://github.com/vic/flake-file/blob/main/modules/allfollow.nix) that enables this using [`spikespaz/allfollow`](https://github.com/spikespaz/allfollow).
+For flattening mechanisms we provide:
+
+- [`flakeModules.allfollow`](https://github.com/vic/flake-file/blob/main/modules/prune-lock/allfollow.nix) that enables this using [`spikespaz/allfollow`](https://github.com/spikespaz/allfollow)
+- [`flakeModules.nix-auto-follow`](https://github.com/vic/flake-file/blob/main/modules/prune-lock/nix-auto-follow.nix) that enables this using [`fzakaria/nix-auto-follow`](https://github.com/fzakaria/nix-auto-follow)
 
 ```nix
 { inputs, ... }:
 {
-  imports = [ inputs.flake-file.flakeModules.allfollow ];
+  imports = [
+    inputs.flake-file.flakeModules.allfollow
+    # or optionally
+    #inputs.flake-file.flakeModules.nix-auto-follow
+  ];
 }
 ```
 

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -3,6 +3,7 @@ let
     inherit
       default
       allfollow
+      nix-auto-follow
       dendritic
       import-tree
       ;
@@ -14,6 +15,8 @@ let
   ];
 
   allfollow.imports = [ ./prune-lock/allfollow.nix ];
+
+  nix-auto-follow.imports = [ ./prune-lock/nix-auto-follow.nix ];
 
   import-tree.imports = [ ./import-tree.nix ];
 

--- a/modules/prune-lock/nix-auto-follow.nix
+++ b/modules/prune-lock/nix-auto-follow.nix
@@ -1,0 +1,14 @@
+{ lib, inputs, ... }:
+{
+  flake-file.inputs.nix-auto-follow.url = lib.mkDefault "github:fzakaria/nix-auto-follow";
+  flake-file.prune-lock.enable = lib.mkDefault (inputs ? nix-auto-follow);
+  flake-file.prune-lock.program =
+    pkgs:
+    pkgs.writeShellApplication {
+      name = "nix-auto-follow";
+      runtimeInputs = [ inputs.nix-auto-follow.packages.${pkgs.system}.default ];
+      text = ''
+        auto-follow "$1" > "$2"
+      '';
+    };
+}


### PR DESCRIPTION
This adds a module which enables [nix-auto-follow](https://github.com/fzakaria/nix-auto-follow) to be used as an alternative to [allfollow](https://github.com/spikespaz/allfollow).

It is currently working but for now it's just a straight copy of the allfollow module with minimum needed adjustments to make it work.

I do get an error if I try to run `write-flake` a second time which I don't understand:
```
❯ nix run .#write-flake
warning: Git tree '/home/ginkogruen/.nixfiles' is dirty
error:
       … while evaluating an expression to select 'drvPath' on it
         at «internal»:1:552:
       … while evaluating strict
         at «internal»:1:552:
       (stack trace truncated; use '--show-trace' to show the full trace)

       error: python3.13-types-Pygments-2.17.0.20240310 does not configure a `format`. To build with setuptools as before, set `pyproject = true` and `build-system = [ setuptools ]`.`
```

I also still need to update the documentation to reflect this change.

Also I'm unsure if there needs to be some kind of mechanism that prevents someone from importing multiple flake formatting modules.

Let me know if there are any other things that need to be considered before the PR can be merged.