### PR TITLE
fix: use `attrsOf anything` instead of `attrs`

### DIFF
--- a/modules/options/flake-file.nix
+++ b/modules/options/flake-file.nix
@@ -13,7 +13,39 @@
         nixConfig = lib.mkOption {
           default = { };
           description = "nix config";
-          type = lib.types.attrsOf lib.types.anything;
+          type = lib.types.submodule {
+            freeformType = lib.types.attrsOf lib.types.anything;
+
+            options = {
+              substituters = lib.mkOption {
+                type = lib.types.listOf lib.types.str;
+                description = ''
+                  List of binary cache URLs used to obtain pre-built binaries
+                  of Nix packages.
+                '';
+              };
+
+              extra-substituters = lib.mkOption {
+                type = lib.types.listOf lib.types.str;
+                description = ''
+                  List of binary cache URLs used to obtain pre-built binaries
+                  of Nix packages.
+                '';
+              };
+
+              trusted-public-keys = lib.mkOption {
+                type = lib.types.listOf lib.types.str;
+                example = [ "hydra.nixos.org-1:CNHJZBh9K4tP3EKF6FkkgeVYsS3ohTl+oS0Qa8bezVs=" ];
+                description = "List of public keys used to sign binary caches.";
+              };
+
+              extra-trusted-public-keys = lib.mkOption {
+                type = lib.types.listOf lib.types.str;
+                example = [ "hydra.nixos.org-1:CNHJZBh9K4tP3EKF6FkkgeVYsS3ohTl+oS0Qa8bezVs=" ];
+                description = "List of public keys used to sign binary caches.";
+              };
+            };
+          };
         };
       };
     };

--- a/modules/write-flake.nix
+++ b/modules/write-flake.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  options,
   config,
   inputs,
   ...
@@ -80,9 +81,16 @@ let
   '';
 
   nixConfig =
-    if flake-file.nixConfig != { } then
+    let
+      nixConfigOptions =
+        options.flake-file.valueMeta.configuration.options.nixConfig.valueMeta.configuration.options;
+      filteredConfig = lib.filterAttrs (
+        name: _: !(nixConfigOptions ? ${name}) || nixConfigOptions.${name}.isDefined
+      ) flake-file.nixConfig;
+    in
+    if filteredConfig != { } then
       ''
-        nixConfig = ${nixCode flake-file.nixConfig};
+        nixConfig = ${nixCode filteredConfig};
       ''
     else
       "";


### PR DESCRIPTION
this has more predictable merging behaviour, `attrs` was silently discarding substituters defined in different files. this pr removes the silent discard behaviour by using a `freeformType` of `attrsOf anything` as recommended by the nixos manual, and allows merging commonly used list options by manually defining them.

from [the nixos manual](https://nixos.org/manual/nixos/stable/#sec-option-types-basic):

> **Warning**
> This type will be deprecated in the future because it doesn’t recurse into attribute sets, silently drops earlier attribute definitions, and doesn’t discharge lib.mkDefault, lib.mkIf and co. For allowing arbitrary attribute sets, prefer types.attrsOf types.anything instead which doesn’t have these problems.