### PR TITLE
Update inputs.nixpkgs-lib.follows to "nixpkgs"

### DIFF
--- a/modules/dendritic/dendritic.nix
+++ b/modules/dendritic/dendritic.nix
@@ -8,7 +8,7 @@
 
   flake-file.inputs = {
     flake-parts.url = lib.mkDefault "github:hercules-ci/flake-parts";
-    flake-parts.inputs.nixpkgs-lib.follows = lib.mkDefault "nixpkgs-lib";
+    flake-parts.inputs.nixpkgs-lib.follows = lib.mkDefault "nixpkgs";
   };
 
   flake-file.outputs = lib.mkDefault "dendritic";


### PR DESCRIPTION
Updated to "nixpkgs" to avoid self-reference when bootstrapping new flake.nix using the dendritic module:

`error: input 'flake-parts/nixpkgs-lib' follows a non-existent input 'nixpkgs-lib'`

Thanks for flake-file and putting together the dendritic module, it's been really interesting to learn the past couple days.