### PR TITLE
Expose `flake-file.apps` as flake `apps`, not `packages`

### DIFF
--- a/modules/flake-parts.nix
+++ b/modules/flake-parts.nix
@@ -3,7 +3,7 @@
   perSystem =
     { pkgs, ... }:
     {
-      packages = lib.mapAttrs (_: f: f pkgs) config.flake-file.apps;
+      apps = lib.mapAttrs (_: f: { program = f pkgs; }) config.flake-file.apps;
       checks.check-flake-file = config.flake-file.check-flake-file pkgs;
     };
 }


### PR DESCRIPTION
I was cleaning up my flake outputs and noticed that `write-flake`, `write-lock`, `write-inputs`, and others are exposed as flake outputs `packages` instead of flake outputs `apps`.

```shell-session
$ nix flake init --template github:vic/flake-file#dendritic
$ nix flake show
path: <path/to/new/flake>
├───apps
│   └───x86_64-linux
└───packages
    └───x86_64-linux
        ├───write-flake: package
        ├───write-inputs: package
        └───write-lock: package
```

Since `packages` are supposed to be build artefacts and/or something installable, and these are, unless I misunderstood the intention, all just quick and small scripts only useful for the current configuration directory and are not expected to be installed and available on `PATH` for general use in other directories, I think having them as `app`s would be more appropriate.

Now:

```shell-session
$ nix flake init --template github:vic/flake-file#dendritic
$ nix flake show
path: <path/to/new/flake>
├───apps
│   └───x86_64-linux
│       ├───write-flake: package
│       ├───write-inputs: package
│       └───write-lock: package
└───packages
    └───x86_64-linux
```

The change is applied only when setting the `perSystem` flake outputs, so hopefully it should not break anything in flake-ile, as all references use the unmodified `flake-file.apps`.

Feel free to close the PR if exposing the scripts as `packages` was intentional or something.

I think the same can be done to https://github.com/vic/den/blob/b7f910ab47260c91a0ae8d55fa72cd2178ba2458/templates/default/modules/nh.nix#L7.