### PR TITLE
feat: output write-* to packages also

### DIFF
--- a/modules/flake-parts.nix
+++ b/modules/flake-parts.nix
@@ -3,7 +3,7 @@
   perSystem =
     { pkgs, ... }:
     {
-      apps = lib.mapAttrs (_: f: { program = f pkgs; }) config.flake-file.apps;
+      packages = lib.mapAttrs (_: f: f pkgs) config.flake-file.apps;
       checks.check-flake-file = config.flake-file.check-flake-file pkgs;
     };
 }

--- a/modules/nixlock/default.nix
+++ b/modules/nixlock/default.nix
@@ -92,6 +92,7 @@ let
     in
     pkgs.writeShellApplication {
       name = "write-nixlock";
+      meta.description = "Generate nixlock.lock.nix via nixlock.";
       excludeShellChecks = [
         "SC2016"
         "SC2086"

--- a/modules/npins/default.nix
+++ b/modules/npins/default.nix
@@ -49,6 +49,7 @@ let
     pkgs:
     pkgs.writeShellApplication {
       name = "write-npins";
+      meta.description = "Generate/update npins/ directory via npins.";
       runtimeInputs = [
         pkgs.npins
         pkgs.jq

--- a/modules/unflake/default.nix
+++ b/modules/unflake/default.nix
@@ -6,6 +6,7 @@ let
     pkgs:
     pkgs.writeShellApplication {
       name = "write-unflake";
+      meta.description = "Generate unflake.nix via unflake.";
       text = ''
         cd ${flake-file.intoPath}
         nix-shell "${flake-file.unflake.url}" -A unflake-shell --run "unflake -i ${flake-file.inputsFile pkgs} $*"

--- a/modules/write-flake.nix
+++ b/modules/write-flake.nix
@@ -108,6 +108,7 @@ let
     in
     pkgs.writeShellApplication {
       name = "write-flake";
+      meta.description = "Generate a flake.nix file";
       text = ''
         cd ${config.flake-file.intoPath}
         cat ${formatted pkgs} > flake.nix

--- a/modules/write-inputs.nix
+++ b/modules/write-inputs.nix
@@ -26,6 +26,7 @@ let
     pkgs:
     pkgs.writeShellApplication {
       name = "write-inputs";
+      meta.description = "Generate an inputs.nix expression (for debugging)";
       text = ''
         cd ${flake-file.intoPath}
         cat ${inputsFile pkgs} > "''${1:-inputs.nix}"

--- a/modules/write-lock.nix
+++ b/modules/write-lock.nix
@@ -32,6 +32,7 @@ let
     pkgs:
     pkgs.writeShellApplication {
       name = "write-lock";
+      meta.description = "Detect existing lock file and delegate to the appropriate writer.";
       runtimeInputs = map (d: apps.${d.app} pkgs) available;
       text = dispatch;
     };


### PR DESCRIPTION
This is useful since the `apps` output doesn't give you easy access to a derivation, as far as I can tell, so it's harder to include in something like `devshells`