### PR TITLE
fix: export write-lock with flakeless-parts

### DIFF
--- a/modules/flakeless-parts.nix
+++ b/modules/flakeless-parts.nix
@@ -5,8 +5,15 @@
   perSystem =
     { pkgs, ... }:
     {
-      apps.write-npins = {
-        program = config.flake-file.apps.write-npins pkgs;
-      };
+      packages = lib.pipe config.flake-file.apps [
+        (lib.filterAttrs (
+          n: _:
+          lib.elem n [
+            "write-npins"
+            "write-lock"
+          ]
+        ))
+        (lib.mapAttrs (_: v: v pkgs))
+      ];
     };
 }


### PR DESCRIPTION
I had hard-coded the inclusion of `write-npins`, which kept `write-lock` from showing up in `nix flake show`. This fixes that so an end-user can use `nix run .#write-lock` with the flakeless-parts setup, too.