### PR TITLE
feat: preferLocalBuild

### DIFF
--- a/modules/write-flake.nix
+++ b/modules/write-flake.nix
@@ -89,6 +89,7 @@ let
       name = "flake-formatted";
       passAsFile = [ "unformatted" ];
       inherit unformatted;
+      preferLocalBuild = true;
       phases = [ "format" ];
       format = ''
         cp $unformattedPath flake.nix
@@ -126,7 +127,7 @@ let
         (lib.concatStringsSep "\n")
       ];
     in
-    pkgs.runCommand "check-flake-file"
+    pkgs.runCommandLocal "check-flake-file"
       {
         nativeBuildInputs = [ pkgs.diffutils ];
       }

--- a/modules/write-inputs.nix
+++ b/modules/write-inputs.nix
@@ -20,6 +20,7 @@ let
       copy = ''
         cp $inputsStringPath $out
       '';
+      preferLocalBuild = true;
     };
 
   write-inputs =


### PR DESCRIPTION
The apps exported like `write-flake` are written in a way that nix will first try to reach out to caches and remote builders before performing a local build. This is very annoying since it slows down the build a lot, especially if you have a lot of caches (nix-community.cachix.org, cache.garnix.io, etc.). But caches and remote builders will never be able to serve these, so it is pointless in even trying.

This patch adds preferLocalBuild to all `runCommand`'s and `mkDerivation`'s I found with `rg`.