### PR TITLE
Add Support for Git LFS on Inputs

### DIFF
--- a/dev/modules/_lib/default.nix
+++ b/dev/modules/_lib/default.nix
@@ -53,6 +53,7 @@ let
       url = { };
       type = { };
       submodules = { };
+      lfs = { };
       owner = { };
       repo = { };
       path = { };

--- a/docs/src/content/docs/reference/options.mdx
+++ b/docs/src/content/docs/reference/options.mdx
@@ -35,6 +35,7 @@ Each input is declared under `flake-file.inputs.<name>`.
 | `flake-file.inputs.<name>.ref` | `str` | Branch or tag pin |
 | `flake-file.inputs.<name>.host` | `str` | Custom host for git forges |
 | `flake-file.inputs.<name>.submodules` | `bool` | Whether to fetch git submodules |
+| `flake-file.inputs.<name>.lfs` | `bool` | Whether to fetch with git LFS support |
 | `flake-file.inputs.<name>.flake` | `bool` | Is the input a flake? (default: `true`) |
 | `flake-file.inputs.<name>.follows` | `str` | Follow another input's resolved value |
 | `flake-file.inputs.<name>.inputs.<dep>.follows` | `str` | Nested transitive follow |

--- a/modules/options/inputs.nix
+++ b/modules/options/inputs.nix
@@ -52,6 +52,11 @@ let
             default = null;
             type = lib.types.nullOr lib.types.bool;
           };
+          lfs = lib.mkOption {
+            description = "Whether to checkout with git LFS support";
+            default = null;
+            type = lib.types.nullOr lib.types.bool;
+          };
           owner = lib.mkOption {
             description = "owner of the repository";
             default = "";

--- a/modules/options/style.nix
+++ b/modules/options/style.nix
@@ -51,6 +51,7 @@ in
         "rev"
         "ref"
         "submodules"
+        "lfs"
         "flake"
         "follows"
         "inputs"


### PR DESCRIPTION
Adds support for flake inputs which use `lfs = true` in the flake-file inputs schema. Fixes #111.