### PR TITLE
feat: add support for shallow fetching inputs

### DIFF
--- a/dev/modules/_lib/default.nix
+++ b/dev/modules/_lib/default.nix
@@ -63,6 +63,7 @@ let
       rev = { };
       ref = { };
       host = { };
+      shallow = { };
       flake = {
         testEmpty = v: v;
         nonEmptyMerge = {

--- a/docs/src/content/docs/reference/options.mdx
+++ b/docs/src/content/docs/reference/options.mdx
@@ -35,6 +35,7 @@ Each input is declared under `flake-file.inputs.<name>`.
 | `flake-file.inputs.<name>.ref` | `str` | Branch or tag pin |
 | `flake-file.inputs.<name>.host` | `str` | Custom host for git forges |
 | `flake-file.inputs.<name>.submodules` | `bool` | Whether to fetch git submodules |
+| `flake-file.inputs.<name>.shallow` | `bool` | Whether to fetch shallowly |
 | `flake-file.inputs.<name>.lfs` | `bool` | Whether to fetch with git LFS support |
 | `flake-file.inputs.<name>.flake` | `bool` | Is the input a flake? (default: `true`) |
 | `flake-file.inputs.<name>.follows` | `str` | Follow another input's resolved value |

--- a/modules/options/inputs.nix
+++ b/modules/options/inputs.nix
@@ -52,6 +52,11 @@ let
             default = null;
             type = lib.types.nullOr lib.types.bool;
           };
+          shallow = lib.mkOption {
+            description = "Whether to shallow checkout git repos";
+            default = null;
+            type = lib.types.nullOr lib.types.bool;
+          };
           lfs = lib.mkOption {
             description = "Whether to checkout with git LFS support";
             default = null;

--- a/modules/options/style.nix
+++ b/modules/options/style.nix
@@ -50,6 +50,7 @@ in
         "narHash"
         "rev"
         "ref"
+        "shallow"
         "submodules"
         "lfs"
         "flake"


### PR DESCRIPTION
Adds support for flake inputs supporting `shallow = true` in the flake-file inputs.schema. Fixes #121 