### PR TITLE
fix: updates Tack pin to v1.0.0

### DIFF
--- a/modules/tack/default.nix
+++ b/modules/tack/default.nix
@@ -6,8 +6,8 @@ let
   serialize = import ./serialize.nix lib;
 
   tackSrc = fetchTarball {
-    url = "https://github.com/manic-systems/tack/archive/8c574901340af860979500f24495417ce7e53cdc.tar.gz";
-    sha256 = "sha256-5dYWCjKBwjHOCJBlQK9iBKJxoUosTGQvI62vPBdQUgs=";
+    url = "https://github.com/manic-systems/tack/archive/refs/tags/v1.0.0.tar.gz";
+    sha256 = "sha256-KhJb0NWLhj8AkD8uWEbXt179YlFLemk0OgOltw4jEk8=";
   };
 
   cfg = flake-file.tack;


### PR DESCRIPTION
## Summary

Updates the pinned Tack fallback package to Tack `v1.0.0`.

## What changed

- Replaces the old Tack source tarball pinned to commit
  `8c574901340af860979500f24495417ce7e53cdc` with the `v1.0.0` release
  tarball.
- Updates the source hash accordingly.

## Why

The old Tack revision depends on `git2`/`libgit2-sys`. Its `libgit2-sys`
version requires `libgit2 >= 1.9.3`, while nixpkgs can sometimes provide
`libgit2 1.9.2` (this was the case with me: I created a thread about this on
Zullip, but no replies. Hence, PR). Because that old Tack package sets
`LIBGIT2_NO_VENDOR`, the build fails instead of falling back to vendored
`libgit2`.

Tack `v1.0.0` has moved away from `git2`/`libgit2-sys` and builds successfully
in this environment.

## Testing

```sh
nix-shell ./dev/bootstrap-tests.nix --run test-all
```

Result on this branch:

- Tack builds successfully.
- `test-tack` passes.
- `test-write-lock-tack` passes.
- The full suite still fails at `test-write-lock-npins` because of a separate
  npins fixture issue fixed in the follow-up PR
  `test/npins-lock-fixture-version`.

Targeted Tack smoke test:

```sh
nix-shell -E '
let
  pkgs = import <nixpkgs> { };
  ff = import ./. { inherit pkgs; modules = {
    inputs.empty.url = "github:vic/empty-flake";
    outputs = _: { };
  }; };
in
pkgs.mkShell {
  buildInputs = [ (ff.flake-file.apps.write-tack pkgs) ];
}
' --run 'write-tack --help || true'
```

Result: passed.

Feel free to verify results for yourself.

## Related work

This PR intentionally fixes only the Tack package compatibility issue. The full
set of related changes has also been validated together on the integration
branch:

```text
chore/integration-verify-bootstrap-fixes
```

That integration branch includes this PR plus the standalone writer target,
npins fixture, and bootstrap argument work that I did.