### PR TITLE
test: initializes npins lock fixture with npins

### DIFF
--- a/dev/_bootstrap-tests.nix
+++ b/dev/_bootstrap-tests.nix
@@ -190,10 +190,11 @@ let
     runtimeInputs = [
       (empty.flake-file.apps.write-lock pkgs)
       pkgs.jq
+      pkgs.npins
     ];
     text = ''
-      mkdir -p ${outdir}/npins
-      echo '{"pins":{},"version":8}' > ${outdir}/npins/sources.json
+      mkdir -p ${outdir}
+      (cd ${outdir} && npins init --bare)
       write-lock
       jq -e '.pins | has("empty")' ${outdir}/npins/sources.json
     '';


### PR DESCRIPTION
## Summary

Updates the `test-write-lock-npins` fixture to let `npins` create its own empty
lock state instead of hardcoding a `sources.json` schema version.

## What changed

- Adds `pkgs.npins` to the test runtime inputs.
- Replaces this hardcoded fixture:

```sh
echo '{"pins":{},"version":8}' > npins/sources.json
```

with:

```sh
(cd ${outdir} && npins init --bare)
```

## Why

The test is intended to verify that `write-lock` detects an existing
`npins/sources.json` and delegates to `write-npins`.

It should not depend on a hand-written npins lockfile schema version. In one
local environment (mine, lol), the hardcoded `version = 8` fixture failed with:

```text
Unknown version 8, maybe try updating the application?
```

Using `npins init --bare` makes the fixture compatible with the `npins` package
that is actually used by the test.

## Testing

This branch depends on the Tack compatibility fix for full CI, because
`write-lock` currently realizes all lock backends, including Tack.

Validated on the combined integration branch:

```sh
git switch chore/integration-verify-bootstrap-fixes
nix-shell ./dev/bootstrap-tests.nix --run test-all
```

Result: passed. Feel free to verify for yourself.

On this branch alone, `test-write-lock-npins` may still attempt to build old Tack
from `main` through `write-lock`. That issue is fixed by
`fix/tack-libgit2-compat`.

## Related work

This PR is intentionally test-only and should be reviewed after or alongside
`fix/tack-libgit2-compat`. The reason I am breaking up my PRs like this is for
auditability, but feel free to supersede them if need may be.

The validated integration branch is:

```text
chore/integration-verify-bootstrap-fixes
```