### PR TITLE
fix: enables documented bootstrap input defaults

### DIFF
--- a/dev/_bootstrap-tests.nix
+++ b/dev/_bootstrap-tests.nix
@@ -137,8 +137,12 @@ let
       write-inputs
       grep github:vic/flake-file ${outdir}/inputs.nix
       grep nixpkgs-unstable ${outdir}/inputs.nix
-      ! grep github:vic/import-tree ${outdir}/inputs.nix
-      ! grep github:hercules-ci/flake-parts ${outdir}/inputs.nix
+      if grep github:vic/import-tree ${outdir}/inputs.nix; then
+        exit 1
+      fi
+      if grep github:hercules-ci/flake-parts ${outdir}/inputs.nix; then
+        exit 1
+      fi
     '';
   };
 

--- a/dev/_bootstrap-tests.nix
+++ b/dev/_bootstrap-tests.nix
@@ -48,6 +48,36 @@ let
     inputs.flake-parts.url = "github:hercules-ci/flake-parts";
   };
 
+  bootstrap-all = import ./.. (
+    args
+    // {
+      bootstrap = true;
+      modules = { outputs = _: { }; };
+    }
+  );
+
+  bootstrap-selected = import ./.. (
+    args
+    // {
+      bootstrap = [
+        "flake-file"
+        "nixpkgs"
+      ];
+      modules = { outputs = _: { }; };
+    }
+  );
+
+  bootstrap-override = import ./.. (
+    args
+    // {
+      bootstrap = true;
+      modules = {
+        inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+        outputs = _: { };
+      };
+    }
+  );
+
   flake-parts-follows = bootstrap {
     inputs.nixpkgs-lib.url = "github:vic/empty-flake";
     inputs.flake-parts.url = "github:hercules-ci/flake-parts";
@@ -81,6 +111,45 @@ let
       write-flake
       cat ${outdir}/flake.nix
       grep github:vic/empty-flake ${outdir}/flake.nix
+    '';
+  };
+
+  test-bootstrap-all-inputs = pkgs.writeShellApplication {
+    name = "test-bootstrap-all-inputs";
+    runtimeInputs = [
+      (bootstrap-all.flake-file.apps.write-inputs pkgs)
+    ];
+    text = ''
+      write-inputs
+      grep github:vic/import-tree ${outdir}/inputs.nix
+      grep github:vic/flake-file ${outdir}/inputs.nix
+      grep github:hercules-ci/flake-parts ${outdir}/inputs.nix
+      grep nixpkgs-unstable ${outdir}/inputs.nix
+    '';
+  };
+
+  test-bootstrap-selected-inputs = pkgs.writeShellApplication {
+    name = "test-bootstrap-selected-inputs";
+    runtimeInputs = [
+      (bootstrap-selected.flake-file.apps.write-inputs pkgs)
+    ];
+    text = ''
+      write-inputs
+      grep github:vic/flake-file ${outdir}/inputs.nix
+      grep nixpkgs-unstable ${outdir}/inputs.nix
+      ! grep github:vic/import-tree ${outdir}/inputs.nix
+      ! grep github:hercules-ci/flake-parts ${outdir}/inputs.nix
+    '';
+  };
+
+  test-bootstrap-input-override = pkgs.writeShellApplication {
+    name = "test-bootstrap-input-override";
+    runtimeInputs = [
+      (bootstrap-override.flake-file.apps.write-inputs pkgs)
+    ];
+    text = ''
+      write-inputs
+      grep github:nixos/nixpkgs/nixos-unstable ${outdir}/inputs.nix
     '';
   };
 
@@ -245,6 +314,9 @@ pkgs.mkShell {
   buildInputs = [
     test-inputs
     test-flake
+    test-bootstrap-all-inputs
+    test-bootstrap-selected-inputs
+    test-bootstrap-input-override
     test-unflake
     test-npins
     test-npins-schemes

--- a/docs/src/content/docs/reference/bootstrap.mdx
+++ b/docs/src/content/docs/reference/bootstrap.mdx
@@ -46,7 +46,7 @@ The Nix file or directory containing your flake-file module definitions. All `.n
 
 ### `bootstrap`
 
-Include predefined inputs from the built-in `bootstrap.nix`. When set to `true`, all bootstrap inputs are included. When set to a list, only the named inputs are included.
+Include predefined inputs from `modules/bootstrap/inputs.nix`. When set to `true`, all bootstrap inputs are included. When set to a list, only the named inputs are included. These defaults are imported before your modules, so your modules can override them.
 
 - **Type:** `true` | list of input names
 - **Default:** `[]` (none)

--- a/modules/bootstrap/default.nix
+++ b/modules/bootstrap/default.nix
@@ -1,6 +1,7 @@
 {
   pkgs ? import <nixpkgs> { },
   modules ? [ ],
+  bootstrap ? [ ],
   outdir ? ".",
   inputs ? null,
   outputs ? null,
@@ -20,6 +21,19 @@ let
 
   tree = (import import-tree) modules;
 
+  bootstrapModule =
+    if bootstrap == true then
+      ./inputs.nix
+    else if builtins.isList bootstrap then
+      let
+        allInputs = (import ./inputs.nix { inherit lib; }).flake-file.inputs;
+      in
+      { flake-file.inputs = lib.filterAttrs (name: _: builtins.elem name bootstrap) allInputs; }
+    else if bootstrap == false then
+      { }
+    else
+      throw "flake-file bootstrap must be true, false, or a list of input names";
+
   attrsOpt = lib.mkOption {
     default = { };
     type = lib.types.submodule { freeformType = lib.types.lazyAttrsOf lib.types.unspecified; };
@@ -27,6 +41,7 @@ let
 
   module = {
     imports = [
+      bootstrapModule
       tree
       ./../default.nix
       ./../options


### PR DESCRIPTION
## Summary

Implements the documented `bootstrap` argument for the bootstrap entrypoint.

## What changed

- Adds an explicit `bootstrap` function argument.
- Imports `modules/bootstrap/inputs.nix` when `bootstrap = true`.
- Supports selecting a subset of bootstrap inputs with a list.
- Documents that bootstrap inputs are defaults and can be overridden by caller
  modules.
- Adds tests for:
  - all bootstrap inputs;
  - selected bootstrap inputs;
  - overriding a bootstrap default from user modules.

## Why

The docs described `--arg bootstrap true`, but the bootstrap function accepted it
only through `...` and did not use it. That made the documented argument a
silent no-op.

Notably, I am not sure if keeping `...` on the input attr set is preferable or
not. It would be a way to ensure that silent behavior that PRs like this fix
would not occur anymore, but I'd like someone else's opinion.

This PR makes the documented behavior observable and covered by tests.

## Testing

Targeted bootstrap argument test command:

```sh
git switch fix/bootstrap-argument
nix-shell -E '
let
  pkgs = import <nixpkgs> { };
  s = import ./dev/_bootstrap-tests.nix { inherit pkgs; };
  test = name: builtins.head (
    builtins.filter (x: x.name == name) s.buildInputs
  );
in
pkgs.mkShell {
  buildInputs = [
    (test "test-bootstrap-all-inputs")
    (test "test-bootstrap-selected-inputs")
    (test "test-bootstrap-input-override")
  ];
}
' --run '
  test-bootstrap-all-inputs &&
  test-bootstrap-selected-inputs &&
  test-bootstrap-input-override
'
```

Result: passed locally.

Full integration suite:

```sh
git switch chore/integration-verify-bootstrap-fixes
nix-shell ./dev/bootstrap-tests.nix --run test-all
```

Result: passed after merging this branch with the related branches.

Once again, verify results for yourself.

## Related work

This PR has public API semantics, so it is kept separate from the package and
test fixture fixes.

It may have small merge overlap with `feat/top-level-writer-targets` in the
bootstrap docs and bootstrap module (and by overlap I do mean merge conflicts).
That overlap was resolved successfully in the validated integration branch:

```text
chore/integration-verify-bootstrap-fixes
```
