### PR TITLE
fix: avoid needless flake.nix/flake.lock rewrites

### DIFF
--- a/modules/options/prune-lock.nix
+++ b/modules/options/prune-lock.nix
@@ -30,10 +30,15 @@ let
     pkgs:
     pkgs.writeShellApplication {
       name = "prune-lock";
+      runtimeInputs = [ pkgs.diffutils ];
       text = ''
-        nix flake metadata > /dev/null
         ${prune-cmd pkgs} flake.lock pruned.lock
-        mv pruned.lock flake.lock
+        if cmp -s flake.lock pruned.lock; then
+          rm pruned.lock
+        else
+          mv pruned.lock flake.lock
+        fi
+        nix flake metadata > /dev/null
       '';
     };
 

--- a/modules/write-flake.nix
+++ b/modules/write-flake.nix
@@ -110,9 +110,12 @@ let
     pkgs.writeShellApplication {
       name = "write-flake";
       meta.description = "Generate a flake.nix file";
+      runtimeInputs = [ pkgs.diffutils ];
       text = ''
         cd ${config.flake-file.intoPath}
-        cat ${formatted pkgs} > flake.nix
+        if ! cmp -s ${formatted pkgs} flake.nix; then
+          cat ${formatted pkgs} > flake.nix
+        fi
         ${hooks}
       '';
     };


### PR DESCRIPTION
## Problem

`write-flake` and `prune-lock-run` both rewrite their target file unconditionally on every run, even when nothing changed:

- `write-flake` does `cat ${formatted pkgs} > flake.nix` unconditionally.
- `prune-lock-run` does `mv pruned.lock flake.lock` unconditionally, and also runs `nix flake metadata` *before* pruning rather than after. For inputs that already declare their own `inputs.nixpkgs.follows`, Nix's own resolution and a lock-pruning `program` can disagree on how to represent that (direct reference vs. some other content-equal node), and since *any* subsequent `nix` invocation re-derives Nix's preferred form, running `nix flake metadata` before pruning means the next invocation partially undoes the prune. It then gets redone next time — forever, on every run.

Net effect: `flake.nix`/`flake.lock` get touched on every run regardless of whether anything meaningful changed, which defeats mtime-based caching downstream and adds unnecessary diff noise.

## Fix

- Only overwrite the target file when the new content actually differs from what's on disk (`cmp -s`).
- Run `nix flake metadata` *after* pruning instead of before, so Nix has the final say.